### PR TITLE
Add missing comma in one test case

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -35,7 +35,8 @@ def test_valid_query(valid_query):
     [
         "",
         "1",
-        "," "wrong",
+        ",",
+        "wrong",
         "vertices",
         "edges",
         "component",


### PR DESCRIPTION
That missing comma was important because it removed one of the test cases.