### PR TITLE
Update dependency pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,3 @@ updates:
       all-dependencies:
         patterns:
           - "*"
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,9 @@ dependencies = [
     "antlr4-python3-runtime>=4.13.2",
     "igraph>=1.0.0",
     "networkx>=3.4.2",
-    "platformdirs>=4.3.6",
-    "rich>=13.9.4",
-    "typer>=0.17.4",
+    "platformdirs>=4.10.0",
+    "rich>=15.0.0",
+    "typer>=0.26.7",
 ]
 dynamic = ["version"]
 keywords = ["graphs", "graph-theory", "database"]
@@ -48,7 +48,7 @@ build-backend = "hatchling.build"
 
 [dependency-groups]
 dev = [
-    "pytest==9.1.1",
+    "pytest>=9.1.1",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
This PR bumps minimum versions for `platformdirs`, `rich`, and `typer`, and relaxes the `pytest` pin from `==` to `>=`. Also, it removes the pip dependabot entry -- with no pinned dependencies there's nothing for it to update.